### PR TITLE
Fix double up strategy in roulette/coinflip

### DIFF
--- a/src/discord/commands/guild/d.rpg.ts
+++ b/src/discord/commands/guild/d.rpg.ts
@@ -3568,9 +3568,7 @@ export async function rpgArcadeGame(
 
   const rowWagers = new ActionRowBuilder<ButtonBuilder>()
     .addComponents(
-      customButton(`rpgWager1,user:${interaction.user.id}`, 'Bet 1', 'buttonBetSmall', ButtonStyle.Success),
-      customButton(`rpgWager10,user:${interaction.user.id}`, 'Bet 10', 'buttonBetMedium', ButtonStyle.Success),
-      customButton(`rpgWager100,user:${interaction.user.id}`, 'Bet 100', 'buttonBetLarge', ButtonStyle.Success),
+      customButton(`rpgWager500,user:${interaction.user.id}`, 'Bet 500', 'buttonBetLarge', ButtonStyle.Success),
       customButton(`rpgWager1000,user:${interaction.user.id}`, 'Bet 1000', 'buttonBetHuge', ButtonStyle.Success),
       customButton(`rpgArcade,user:${interaction.user.id}`, 'Arcade', 'buttonArcade', ButtonStyle.Primary),
     );
@@ -3793,10 +3791,25 @@ export async function getNewTimer(seconds: number) {
 
 export async function rpgArcadeWager(
   interaction: MessageComponentInteraction,
-):Promise<InteractionUpdateOptions> {
-  let newBet = wagers[interaction.user.id] ? wagers[interaction.user.id].tokens : 0;
+): Promise<InteractionUpdateOptions> {
+  // Check if there's already an existing wager that's at max bet (1000)
+  if (wagers[interaction.user.id] && wagers[interaction.user.id].tokens >= 1000) {
+    return rpgArcadeGame(interaction, wagers[interaction.user.id].gameName, undefined, '**Maximum bet is 1000 tokens**\n');
+  }
+
+  const currentBet = wagers[interaction.user.id] ? wagers[interaction.user.id].tokens : 0;
   const bet = parseInt(interaction.customId.slice(8), 10);
-  newBet += bet || 0;
+  let newBet = currentBet + (bet || 0);
+
+  // If new bet would exceed 1000, cap it at 1000
+  if (newBet > 1000) {
+    newBet = 1000;
+  }
+
+  // Ensure minimum bet of 500 (if betting at all)
+  if (newBet > 0 && newBet < 500) {
+    newBet = 500;
+  }
 
   const userData = await db.users.upsert({
     where: {
@@ -3807,6 +3820,7 @@ export async function rpgArcadeWager(
     },
     update: {},
   });
+
   const personaData = await db.personas.upsert({
     where: {
       user_id: userData.id,
@@ -3816,6 +3830,7 @@ export async function rpgArcadeWager(
     },
     update: {},
   });
+
   if (personaData.tokens < newBet) {
     const notEnough = '**You don\'t have enough to bet that much**\n';
     return rpgArcadeGame(interaction, wagers[interaction.user.id].gameName, undefined, notEnough);

--- a/src/discord/events/buttonClick.ts
+++ b/src/discord/events/buttonClick.ts
@@ -97,11 +97,8 @@ export async function buttonClick(interaction:ButtonInteraction, discordClient:C
     else if (interaction.customId.split(',')[0] === 'rpgBounties') await interaction.editReply(await rpgBounties(interaction, null));
     else if (interaction.customId.split(',')[0] === 'rpgArcade') await interaction.editReply(await rpgArcade(interaction));
     else if (interaction.customId.split(',')[0] === 'rpgHelp') await interaction.editReply(await rpgHelp(interaction));
-    else if (interaction.customId.split(',')[0] === 'rpgWager1') await interaction.editReply(await rpgArcadeWager(interaction));
-    else if (interaction.customId.split(',')[0] === 'rpgWager10') await interaction.editReply(await rpgArcadeWager(interaction));
-    else if (interaction.customId.split(',')[0] === 'rpgWager100') await interaction.editReply(await rpgArcadeWager(interaction));
+    else if (interaction.customId.split(',')[0] === 'rpgWager500') await interaction.editReply(await rpgArcadeWager(interaction));
     else if (interaction.customId.split(',')[0] === 'rpgWager1000') await interaction.editReply(await rpgArcadeWager(interaction));
-    else if (interaction.customId.split(',')[0] === 'rpgWager10000') await interaction.editReply(await rpgArcadeWager(interaction));
     else if (interaction.customId.split(',')[0] === 'rpgCoinFlip') await interaction.editReply(await rpgArcadeGame(interaction, 'Coinflip'));
     else if (interaction.customId.split(',')[0] === 'rpgRouletteRed') await interaction.editReply(await rpgArcadeGame(interaction, 'Roulette', 'red'));
     else if (interaction.customId.split(',')[0] === 'rpgRouletteBlack') await interaction.editReply(await rpgArcadeGame(interaction, 'Roulette', 'black'));


### PR DESCRIPTION
With the strategy being patched at the minimum I would have to lose 17 times in a row to bankrupt. The odds of that are 1 in 131,000. This limits to only 500 and 1000 token buttons with a max bet of 1000, allowing 1 double up and fixing the issue.