### PR TITLE
Noop lifeyard update

### DIFF
--- a/src/global/assets/data/lifeyard.json
+++ b/src/global/assets/data/lifeyard.json
@@ -1,6 +1,6 @@
 {
-  "Title": "This page is dediated to all the friends we've lost. May they live forever in this digital space.",
-  "Description": "Have someone you want to memoralize? Make a new PR to add them here.",
+  "Title": "This page is dedicated to all the friends we've lost. May they live forever in this digital space.",
+  "Description": "Do you have someone you want to memorialize? Make a new PR to add them here.",
   "Lifeyard": [
     "Charles/Kevin",
     "Sleep/Chance",

--- a/src/global/assets/data/lifeyard.json
+++ b/src/global/assets/data/lifeyard.json
@@ -20,7 +20,7 @@
     "_spacey",
     "Psyched_Euphoria",
     "Isometric",
-    "Noop/noop8077",
+    "Noop",
     "ComedownKid"
   ]
 }


### PR DESCRIPTION
Removed noop8077 - he did not use this name, and fixed/reworded a typo and the first line description.