### PR TITLE
Level Freeze

### DIFF
--- a/src/discord/commands/guild/d.leaderboard.ts
+++ b/src/discord/commands/guild/d.leaderboard.ts
@@ -152,7 +152,7 @@ export const dLeaderboard: SlashCommand = {
     }
 
     // Fetch level freezes for just the users we're about to draw, in one query
-    const freezeCaps = await getLevelFreezes(displayEntries.map(entry => entry.user.discord_id));
+    const frozenLevels = await getLevelFreezes(displayEntries.map(entry => entry.user.discord_id));
 
     const CANVAS_W = 520;
     const PAD = 14;
@@ -286,7 +286,7 @@ export const dLeaderboard: SlashCommand = {
       );
       ctx.restore();
 
-      const userLevel = await getTotalLevel(user.total_points, freezeCaps.get(user.discord_id));
+      const userLevel = await getTotalLevel(user.total_points, frozenLevels.get(user.discord_id));
       const levelText = `LV ${userLevel.level}`;
       ctx.font = '12px futura';
       ctx.fillStyle = isFocused ? '#94a3b8' : '#64748b';

--- a/src/discord/commands/guild/d.leaderboard.ts
+++ b/src/discord/commands/guild/d.leaderboard.ts
@@ -8,6 +8,7 @@ import {
   SlashCommandBuilder,
 } from 'discord.js';
 import { leaderboardV2 } from '../../../global/commands/g.leaderboard';
+import { getLevelFreezes } from '../../../global/commands/g.levelFreeze';
 import { getPersonaInfo } from '../../../global/commands/g.rpg';
 import { getTotalLevel } from '../../../global/utils/experience';
 import { SlashCommand } from '../../@types/commandDef';
@@ -150,6 +151,9 @@ export const dLeaderboard: SlashCommand = {
       displayEntries = allValidEntries.slice(0, MAX_DISPLAY);
     }
 
+    // Fetch level freezes for just the users we're about to draw, in one query
+    const freezeCaps = await getLevelFreezes(displayEntries.map(entry => entry.user.discord_id));
+
     const CANVAS_W = 520;
     const PAD = 14;
     const ROW_H = 36;
@@ -282,7 +286,7 @@ export const dLeaderboard: SlashCommand = {
       );
       ctx.restore();
 
-      const userLevel = await getTotalLevel(user.total_points);
+      const userLevel = await getTotalLevel(user.total_points, freezeCaps.get(user.discord_id));
       const levelText = `LV ${userLevel.level}`;
       ctx.font = '12px futura';
       ctx.fillStyle = isFocused ? '#94a3b8' : '#64748b';

--- a/src/discord/commands/guild/d.mod.ts
+++ b/src/discord/commands/guild/d.mod.ts
@@ -1,3 +1,4 @@
+import { stripIndents } from 'common-tags';
 import {
   ChannelType,
   ChatInputCommandInteraction,
@@ -7,10 +8,13 @@ import {
   SlashCommandBuilder,
   TextChannel,
 } from 'discord.js';
-import { stripIndents } from 'common-tags';
+import {
+  getAllLevelFreezes, NICE_LEVEL, removeLevelFreeze, setLevelFreeze,
+} from '../../../global/commands/g.levelFreeze';
+import { deleteWatchRequest, executeWatch } from '../../../global/commands/g.watchuser';
+import { getUserTotalLevel, MAX_EXPERIENCE_LEVEL, MIN_EXPERIENCE_LEVEL } from '../../../global/utils/experience';
 import { SlashCommand } from '../../@types/commandDef';
 import commandContext from '../../utils/context';
-import { deleteWatchRequest, executeWatch } from '../../../global/commands/g.watchuser';
 import { linkThread } from '../../utils/modUtils';
 
 const F = f(__filename);
@@ -225,6 +229,103 @@ export async function lockdown(interaction: ChatInputCommandInteraction): Promis
   await interaction.editReply({ content: `Channel ${channel} has been locked down.` });
   return true;
 }
+// Requested by Ruubert and yes, we actually developed it
+async function freezeLevel(interaction: ChatInputCommandInteraction): Promise<boolean> {
+  if (!interaction.guild) {
+    await interaction.editReply({ content: SERVER_ONLY_TEXT });
+    return false;
+  }
+
+  const targetUser = interaction.options.getUser('target', true);
+  const level = interaction.options.getInteger('level', true);
+
+  try {
+    await setLevelFreeze(targetUser.id, level);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      // eslint-disable-next-line max-len
+      await interaction.editReply({ content: `The level must be a whole number between ${MIN_EXPERIENCE_LEVEL} and ${MAX_EXPERIENCE_LEVEL}.` });
+      return false;
+    }
+    log.error(F, `Failed to freeze level for ${targetUser.id}: ${error}`);
+    await interaction.editReply({ content: 'Something went wrong setting that level freeze. Please try again.' });
+    return false;
+  }
+
+  const nice = level === NICE_LEVEL;
+  const niceBit = level === NICE_LEVEL ? ' Nice. 😏' : '';
+  // eslint-disable-next-line max-len
+  await interaction.editReply({ content: `Done! **${targetUser.username}**'s displayed level is now frozen at ${level}.${niceBit}` });
+
+  const modName = (interaction.member as GuildMember).displayName;
+  const channelBotlog = await interaction.guild.channels.fetch(env.CHANNEL_BOTLOG) as TextChannel;
+  if (channelBotlog) {
+    // eslint-disable-next-line max-len
+    const botlogMsg = `${modName} froze ${targetUser.username} (${targetUser.id}) at displayed level ${level}`;
+    await channelBotlog.send(nice ? `${botlogMsg}. Nice. 😎` : botlogMsg);
+  }
+  return true;
+}
+
+async function unfreezeLevel(interaction: ChatInputCommandInteraction): Promise<boolean> {
+  if (!interaction.guild) {
+    await interaction.editReply({ content: SERVER_ONLY_TEXT });
+    return false;
+  }
+
+  const targetUser = interaction.options.getUser('target', true);
+
+  if (!await removeLevelFreeze(targetUser.id)) {
+    // eslint-disable-next-line max-len
+    await interaction.editReply({ content: `**${targetUser.username}** doesn't have their displayed level frozen.` });
+    return false;
+  }
+
+  await interaction.editReply({ content: `Done! **${targetUser.username}**'s displayed level is no longer frozen.` });
+
+  const modName = (interaction.member as GuildMember).displayName;
+  const channelBotlog = await interaction.guild.channels.fetch(env.CHANNEL_BOTLOG) as TextChannel;
+  if (channelBotlog) {
+    await channelBotlog.send(`${modName} unfroze ${targetUser.username} (${targetUser.id})`);
+  }
+  return true;
+}
+
+async function listFrozenLevels(interaction: ChatInputCommandInteraction): Promise<boolean> {
+  const frozen = await getAllLevelFreezes();
+
+  if (frozen.length === 0) {
+    await interaction.editReply({ content: 'No users currently have their displayed level frozen. ❄️' });
+    return true;
+  }
+
+  const lines = await Promise.all(frozen.map(async ({ discordId, frozenLevel }) => {
+    const trueLevel = await getUserTotalLevel(discordId);
+    const user = await interaction.client.users.fetch(discordId).catch(() => null);
+    const name = user ? user.username : 'unknown user';
+    return `• ${name} (${discordId}): frozen at ${frozenLevel} (true level ${trueLevel})`;
+  }));
+
+  const header = `🧊 Frozen displayed levels (${frozen.length}):`;
+  const pages: string[] = [];
+  let current = header;
+  lines.forEach(line => {
+    if (`${current}\n${line}`.length > 1900) {
+      pages.push(current);
+      current = line;
+    } else {
+      current = `${current}\n${line}`;
+    }
+  });
+  pages.push(current);
+
+  await interaction.editReply({ content: pages[0] });
+  for (let i = 1; i < pages.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await interaction.followUp({ content: pages[i], flags: MessageFlags.Ephemeral });
+  }
+  return true;
+}
 
 export const dMod: SlashCommand = {
   data: new SlashCommandBuilder()
@@ -280,6 +381,26 @@ export const dMod: SlashCommand = {
       .addBooleanOption(option => option.setName('ephemeral')
         .setDescription(EPHEMERAL_TEXT)))
     .addSubcommand(subcommand => subcommand
+      .setName('freezelevel')
+      .setDescription('Freeze a user\'s displayed level (display only; does not affect roles etc)')
+      .addUserOption(option => option.setName('target')
+        .setDescription('The user whose level to freeze')
+        .setRequired(true))
+      .addIntegerOption(option => option.setName('level')
+        .setDescription('The level to pin them at')
+        .setMinValue(MIN_EXPERIENCE_LEVEL)
+        .setMaxValue(MAX_EXPERIENCE_LEVEL)
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
+      .setName('unfreezelevel')
+      .setDescription('Remove a user\'s level freeze, restoring their true displayed level')
+      .addUserOption(option => option.setName('target')
+        .setDescription('The user whose level freeze to remove')
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
+      .setName('frozenlevels')
+      .setDescription('List all users whose displayed level is frozen'))
+    .addSubcommand(subcommand => subcommand
       .setName('link')
       .setDescription('Link one user to another.')
       .addUserOption(option => option.setName('target')
@@ -292,7 +413,14 @@ export const dMod: SlashCommand = {
         .setDescription(EPHEMERAL_TEXT))),
   async execute(interaction) {
     log.info(F, await commandContext(interaction));
-    const ephemeral = interaction.options.getBoolean('ephemeral') ? MessageFlags.Ephemeral : undefined;
+    const subcommand = interaction.options.getSubcommand();
+    // Level-freeze actions are always hidden so the target is never notified.
+    const alwaysEphemeral = subcommand === 'freezelevel'
+      || subcommand === 'unfreezelevel'
+      || subcommand === 'frozenlevels';
+    const ephemeral = (alwaysEphemeral || interaction.options.getBoolean('ephemeral'))
+      ? MessageFlags.Ephemeral
+      : undefined;
     await interaction.deferReply({ flags: ephemeral });
 
     if (!interaction.guild || interaction.guild.id !== env.DISCORD_GUILD_ID.toString()) {
@@ -304,7 +432,7 @@ export const dMod: SlashCommand = {
     const actorIsMod = actor.roles.cache.has(roleModerator.id);
 
     if (actorIsMod) {
-      switch (interaction.options.getSubcommand()) {
+      switch (subcommand) {
         case 'slowmode':
           await slowMode(interaction);
           break;
@@ -319,6 +447,15 @@ export const dMod: SlashCommand = {
           break;
         case 'link':
           await link(interaction);
+          break;
+        case 'freezelevel':
+          await freezeLevel(interaction);
+          break;
+        case 'unfreezelevel':
+          await unfreezeLevel(interaction);
+          break;
+        case 'frozenlevels':
+          await listFrozenLevels(interaction);
           break;
         default:
           break;

--- a/src/discord/commands/guild/d.profile.ts
+++ b/src/discord/commands/guild/d.profile.ts
@@ -430,8 +430,8 @@ export const dProfile: SlashCommand = {
     context.fillText(`${numFormatter(profileData.tokens)}`, 648, 250);
 
     // Level Text (respects a level freeze if one is set for this user)
-    const freezeCap = await getLevelFreeze(targetUser.id);
-    const totalTextData = await getTotalLevel(profileData.totalTextExp + profileData.totalVoiceExp, freezeCap);
+    const frozenLevel = await getLevelFreeze(targetUser.id);
+    const totalTextData = await getTotalLevel(profileData.totalTextExp + profileData.totalVoiceExp, frozenLevel);
     context.fillText(`${totalTextData.level}`, 894, 250);
 
     // Choose and Draw the Level Image

--- a/src/discord/commands/guild/d.profile.ts
+++ b/src/discord/commands/guild/d.profile.ts
@@ -11,6 +11,7 @@ import { SlashCommand } from '../../@types/commandDef';
 import { profile, ProfileData } from '../../../global/commands/g.profile';
 import commandContext from '../../utils/context';
 import { expForNextLevel, getTotalLevel } from '../../../global/utils/experience';
+import { getLevelFreeze } from '../../../global/commands/g.levelFreeze';
 import { getPersonaInfo } from '../../../global/commands/g.rpg';
 import getAsset from '../../utils/getAsset';
 import {
@@ -428,8 +429,9 @@ export const dProfile: SlashCommand = {
     // Tokens Text
     context.fillText(`${numFormatter(profileData.tokens)}`, 648, 250);
 
-    // Level Text
-    const totalTextData = await getTotalLevel(profileData.totalTextExp + profileData.totalVoiceExp);
+    // Level Text (respects a level freeze if one is set for this user)
+    const freezeCap = await getLevelFreeze(targetUser.id);
+    const totalTextData = await getTotalLevel(profileData.totalTextExp + profileData.totalVoiceExp, freezeCap);
     context.fillText(`${totalTextData.level}`, 894, 250);
 
     // Choose and Draw the Level Image

--- a/src/global/commands/g.levelFreeze.ts
+++ b/src/global/commands/g.levelFreeze.ts
@@ -1,0 +1,88 @@
+import { MAX_EXPERIENCE_LEVEL, MIN_EXPERIENCE_LEVEL } from '../utils/experience';
+
+const F = f(__filename);
+
+/** The distinguished level */
+export const NICE_LEVEL = 69;
+
+/**
+ * A "level freeze" pins the level shown for a user (profile, /levels, leaderboard) at a fixed cap.
+ * It is DISPLAY-ONLY: XP keeps accruing and VIP roles / tent access still track the true level, so
+ * removing the freeze restores the shown level instantly. Stored on `users.level_freeze`
+ * (null = not frozen). BLAME RUUBERT FOR THIS FEATURE.
+ */
+
+export function isValidFreezeLevel(level: number): boolean {
+  return Number.isInteger(level)
+    && level >= MIN_EXPERIENCE_LEVEL
+    && level <= MAX_EXPERIENCE_LEVEL;
+}
+
+export async function setLevelFreeze(discordId: string, level: number): Promise<void> {
+  if (!isValidFreezeLevel(level)) {
+    throw new RangeError(
+      `Freeze level must be an integer between ${MIN_EXPERIENCE_LEVEL} and ${MAX_EXPERIENCE_LEVEL}.`,
+    );
+  }
+
+  await db.users.upsert({
+    where: { discord_id: discordId },
+    create: { discord_id: discordId, level_freeze: level },
+    update: { level_freeze: level },
+  });
+
+  log.debug(F, level === NICE_LEVEL
+    ? `Froze ${discordId} at level ${level}. Nice. 😎`
+    : `Froze ${discordId} at level ${level}`);
+}
+
+export async function removeLevelFreeze(discordId: string): Promise<boolean> {
+  const { count } = await db.users.updateMany({
+    where: { discord_id: discordId, level_freeze: { not: null } },
+    data: { level_freeze: null },
+  });
+
+  if (count > 0) {
+    log.debug(F, `Unfroze ${discordId}`);
+  }
+  return count > 0;
+}
+
+export async function getLevelFreeze(discordId: string): Promise<number | null> {
+  const user = await db.users.findUnique({
+    where: { discord_id: discordId },
+    select: { level_freeze: true },
+  });
+  return user?.level_freeze ?? null;
+}
+
+export async function getAllLevelFreezes(): Promise<Array<{ discordId: string; frozenLevel: number }>> {
+  const frozen = await db.users.findMany({
+    where: { level_freeze: { not: null } },
+    select: { discord_id: true, level_freeze: true },
+    orderBy: { level_freeze: 'desc' },
+  });
+
+  return frozen
+    .filter((user): user is { discord_id: string; level_freeze: number } => (
+      user.discord_id !== null && user.level_freeze !== null
+    ))
+    .map(user => ({ discordId: user.discord_id, frozenLevel: user.level_freeze }));
+}
+
+export async function getLevelFreezes(discordIds: string[]): Promise<Map<string, number>> {
+  if (discordIds.length === 0) {
+    return new Map();
+  }
+
+  const frozenUsers = await db.users.findMany({
+    where: { discord_id: { in: discordIds }, level_freeze: { not: null } },
+    select: { discord_id: true, level_freeze: true },
+  });
+
+  return new Map(frozenUsers
+    .filter((user): user is { discord_id: string; level_freeze: number } => (
+      user.discord_id !== null && user.level_freeze !== null
+    ))
+    .map(user => [user.discord_id, user.level_freeze]));
+}

--- a/src/global/commands/g.levels.ts
+++ b/src/global/commands/g.levels.ts
@@ -5,6 +5,7 @@ import {
 } from '../utils/experience';
 
 import { leaderboardV2 } from './g.leaderboard';
+import { getLevelFreeze } from './g.levelFreeze';
 
 export default levels;
 
@@ -66,6 +67,9 @@ export async function levels(
 ):Promise<LevelData> {
   const leaderboardData = await leaderboardV2();
 
+  // If this user's level is frozen, every level shown here is capped to the freeze.
+  const freezeCap = await getLevelFreeze(discordId);
+
   const results = {
     ALL: {
       TOTAL: {
@@ -117,7 +121,7 @@ export async function levels(
       // log.debug(F, `Type: ${typeKey} Category: ${categoryKey} userRank: ${userRank}`);
       const userExperience = categoryData.find(user => user.discord_id === discordId);
       if (!userExperience) continue;
-      const levelData = await getTotalLevel(userExperience.total_points);
+      const levelData = await getTotalLevel(userExperience.total_points, freezeCap);
       // log.debug(F, `levelData: ${JSON.stringify(levelData, null, 2)}`);
       // log.debug(F, `${discordId} is rank ${userRank} ${type} ${category} \
       // level ${levelData.level} userExperience: ${JSON.stringify(userExperience, null, 2)}`);

--- a/src/global/commands/g.levels.ts
+++ b/src/global/commands/g.levels.ts
@@ -67,8 +67,8 @@ export async function levels(
 ):Promise<LevelData> {
   const leaderboardData = await leaderboardV2();
 
-  // If this user's level is frozen, every level shown here is capped to the freeze.
-  const freezeCap = await getLevelFreeze(discordId);
+  // This user's level freeze, if any. Applied to every displayed level in the pass below.
+  const frozenLevel = await getLevelFreeze(discordId);
 
   const results = {
     ALL: {
@@ -121,7 +121,7 @@ export async function levels(
       // log.debug(F, `Type: ${typeKey} Category: ${categoryKey} userRank: ${userRank}`);
       const userExperience = categoryData.find(user => user.discord_id === discordId);
       if (!userExperience) continue;
-      const levelData = await getTotalLevel(userExperience.total_points, freezeCap);
+      const levelData = await getTotalLevel(userExperience.total_points);
       // log.debug(F, `levelData: ${JSON.stringify(levelData, null, 2)}`);
       // log.debug(F, `${discordId} is rank ${userRank} ${type} ${category} \
       // level ${levelData.level} userExperience: ${JSON.stringify(userExperience, null, 2)}`);
@@ -134,6 +134,25 @@ export async function levels(
         total_exp: userExperience.total_points,
         rank: userRank + 1, // 0-based to 1-based
       };
+    }
+  }
+
+  // If this user's level is frozen, pin EVERY category's displayed level to the frozen value,
+  // including categories they have no XP in (which the loop above skips). Ranks are left as-is.
+  if (frozenLevel !== null) {
+    const frozenNextLevel = await expForNextLevel(frozenLevel);
+    for (const type of Object.keys(leaderboardData)) {
+      const typeKey = type as keyof typeof leaderboardData;
+      for (const category of Object.keys(leaderboardData[typeKey])) {
+        const existing = results[typeKey][category];
+        results[typeKey][category] = {
+          level: frozenLevel,
+          level_exp: frozenNextLevel,
+          nextLevel: frozenNextLevel,
+          total_exp: existing ? existing.total_exp : 0,
+          rank: existing ? existing.rank : 0,
+        };
+      }
     }
   }
 

--- a/src/global/utils/experience.ts
+++ b/src/global/utils/experience.ts
@@ -56,7 +56,7 @@ export async function findXPfromLevel(level: number): Promise<number> {
 
 export async function getTotalLevel(
   totalExp:number,
-  freezeCap?: number | null,
+  frozenLevel?: number | null,
 ):Promise<{ level: number, level_points: number }> {
 // ):Promise<Omit<UserExperience, 'id' | 'user_id' | 'type' | 'category' | 'total_points' | 'last_message_at' | 'last_message_channel' | 'created_at'>> {
   // log.debug('totalLevel', `totalExp: ${totalExp}`);
@@ -74,8 +74,10 @@ export async function getTotalLevel(
   }
   // log.debug(F, `END: totalLevel: ${level} | levelPoints: ${levelPoints} | expToLevel: ${expToLevel}`);
 
-  if (freezeCap !== undefined && freezeCap !== null && level > freezeCap) {
-    return { level: freezeCap, level_points: await expForNextLevel(freezeCap) };
+  // A level freeze pins the DISPLAYED level to this exact value, regardless of the true level.
+  // Display-only: the real level and XP are untouched, and VIP roles / tents still use the true level.
+  if (frozenLevel !== undefined && frozenLevel !== null) {
+    return { level: frozenLevel, level_points: await expForNextLevel(frozenLevel) };
   }
 
   return { level, level_points: levelPoints };

--- a/src/global/utils/experience.ts
+++ b/src/global/utils/experience.ts
@@ -1,19 +1,22 @@
 /* eslint-disable max-len */
 
 import {
-  TextChannel,
-  Role,
-  VoiceChannel,
-  GuildMember,
-} from 'discord.js';
-import { stripIndents } from 'common-tags';
-import {
   experience_category, experience_type, user_experience,
 } from '@db/tripbot';
+import { stripIndents } from 'common-tags';
+import {
+  GuildMember,
+  Role,
+  TextChannel,
+  VoiceChannel,
+} from 'discord.js';
 
 const F = f(__filename); // eslint-disable-line
 
 export default experience;
+
+export const MIN_EXPERIENCE_LEVEL = 0;
+export const MAX_EXPERIENCE_LEVEL = 100;
 
 // Get random value between 15 and 25
 const expPoints = env.NODE_ENV === 'production'
@@ -53,6 +56,7 @@ export async function findXPfromLevel(level: number): Promise<number> {
 
 export async function getTotalLevel(
   totalExp:number,
+  freezeCap?: number | null,
 ):Promise<{ level: number, level_points: number }> {
 // ):Promise<Omit<UserExperience, 'id' | 'user_id' | 'type' | 'category' | 'total_points' | 'last_message_at' | 'last_message_channel' | 'created_at'>> {
   // log.debug('totalLevel', `totalExp: ${totalExp}`);
@@ -69,7 +73,28 @@ export async function getTotalLevel(
     expToLevel = newExpToLevel;
   }
   // log.debug(F, `END: totalLevel: ${level} | levelPoints: ${levelPoints} | expToLevel: ${expToLevel}`);
+
+  if (freezeCap !== undefined && freezeCap !== null && level > freezeCap) {
+    return { level: freezeCap, level_points: await expForNextLevel(freezeCap) };
+  }
+
   return { level, level_points: levelPoints };
+}
+
+export async function getUserTotalLevel(discordId: string): Promise<number> {
+  const userData = await db.users.findUnique({
+    where: { discord_id: discordId },
+    select: { user_experience: { select: { category: true, total_points: true } } },
+  });
+  if (!userData) {
+    return 0;
+  }
+
+  const totalExp = userData.user_experience
+    .filter(exp => exp.category !== 'TOTAL' && exp.category !== 'IGNORED')
+    .reduce((acc, exp) => acc + exp.total_points, 0);
+
+  return (await getTotalLevel(totalExp)).level;
 }
 
 export async function giveMilestone(
@@ -101,7 +126,8 @@ export async function giveMilestone(
   const emojis = [...announcementEmojis].sort(() => 0.5 - Math.random()).slice(0, 3); // Sort the array
 
   // Pretend that the total exp would get the same exp as the category
-  // Get the total level
+  // Get the total level (always the TRUE level — a level freeze is display-only and must never
+  // affect VIP roles, which also gate level-locked tent access).
   const totalData = await getTotalLevel(totalExp);
   // log.debug(F, `${member.displayName} is total Text level ${totalData.level}`);
 

--- a/src/global/utils/experience.ts
+++ b/src/global/utils/experience.ts
@@ -60,6 +60,12 @@ export async function getTotalLevel(
 ):Promise<{ level: number, level_points: number }> {
 // ):Promise<Omit<UserExperience, 'id' | 'user_id' | 'type' | 'category' | 'total_points' | 'last_message_at' | 'last_message_channel' | 'created_at'>> {
   // log.debug('totalLevel', `totalExp: ${totalExp}`);
+
+  // Level freeze is display-only: return the pinned level without computing the true one.
+  if (frozenLevel !== undefined && frozenLevel !== null) {
+    return { level: frozenLevel, level_points: await expForNextLevel(frozenLevel) };
+  }
+
   let level = 0;
   let levelPoints = totalExp;
   let expToLevel = await expForNextLevel(level);
@@ -73,12 +79,6 @@ export async function getTotalLevel(
     expToLevel = newExpToLevel;
   }
   // log.debug(F, `END: totalLevel: ${level} | levelPoints: ${levelPoints} | expToLevel: ${expToLevel}`);
-
-  // A level freeze pins the DISPLAYED level to this exact value, regardless of the true level.
-  // Display-only: the real level and XP are untouched, and VIP roles / tents still use the true level.
-  if (frozenLevel !== undefined && frozenLevel !== null) {
-    return { level: frozenLevel, level_points: await expForNextLevel(frozenLevel) };
-  }
 
   return { level, level_points: levelPoints };
 }

--- a/src/prisma/tripbot/migrations/20260711162919_add_level_freeze/migration.sql
+++ b/src/prisma/tripbot/migrations/20260711162919_add_level_freeze/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "level_freeze" INTEGER;

--- a/src/prisma/tripbot/schema.prisma
+++ b/src/prisma/tripbot/schema.prisma
@@ -36,6 +36,7 @@ model users {
   mod_thread_id                                             String?
   helper_role_ban                                           Boolean              @default(false)
   contributor_role_ban                                      Boolean              @default(false)
+  level_freeze                                              Int?
   lastfm_username                                           String?
   partner                                                   Boolean?             @default(true)
   supporter                                                 Boolean?             @default(false)


### PR DESCRIPTION
Moderators are able to "freeze" and "unfreeze" the level of a user for **_display_** purposes only (profile, level and leaderboard commands). This feature **does not** impact or break true level logic such as level-based VIP roles, level-locked tents and so forth. A new database column was added to the user table to store the value of the "frozen" level. Whether a user has their level frozen or not is determined by whether or not this column has a value or is null. Moderators are also able to draw a list of all users that have their level frozen. The allowed range for a frozen level is 100 >= 0. All actions are logged.