### PR TITLE
Scope UAT Drone pipeline to a dedicated env:uat runner

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -119,6 +119,9 @@ kind: pipeline
 type: docker
 name: Deploy TripBot UAT
 
+node:
+  env: uat
+
 steps:
   - name: Rebuild TripBot UAT
     image: docker


### PR DESCRIPTION
## Summary
Follow-up to #1163. The first attempt assumed a single shared Drone server with a second runner reachable via a `UAT_DOCKER_HOST` secret — turns out that doesn't fit the actual requirement (a genuinely separate Drone server on the UAT box, `drone.tripsit.io`, so junior devs can get access there without touching `drone.tripsit.me`).

Since both Drone servers will evaluate this same `.drone.yml` if the repo ends up activated on both, adds a `node: { env: uat }` selector to the UAT pipeline. This means:
- Live's runner (no `env:uat` label) can never be scheduled for the UAT pipeline, even if Live's Drone server also sees it.
- A future `node: { env: prod }` selector on the prod pipeline gives the same protection in reverse, once Live's runner is labeled.

**Not included yet:** the `node: { env: prod }` selector on the prod pipeline. Adding it now would immediately break live deploys, since Live's existing `drone_runner` doesn't have an `env:prod` label yet. That'll be a separate follow-up once the label's live on that box.

## Test plan
- [x] Confirmed `.drone.yml` still parses as valid multi-doc YAML, prod pipeline's trigger/config unchanged
- [ ] Once the UAT Drone server + labeled runner exist, confirm a push to `uat` actually gets scheduled there

🤖 Generated with [Claude Code](https://claude.com/claude-code)