### PR TITLE
Add GuardMainSource workflow to restrict PRs into main to uat

### DIFF
--- a/.github/workflows/GuardMainSource.yml
+++ b/.github/workflows/GuardMainSource.yml
@@ -1,0 +1,22 @@
+name: GuardMainSource
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  require-uat-source:
+    name: Require uat source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request comes from uat
+        if: github.head_ref != 'uat'
+        run: |
+          echo "::error::Pull requests into main must come from the uat branch (this PR's source is '${{ github.head_ref }}')."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds a required-check workflow (`GuardMainSource.yml`) that fails any pull request targeting `main` unless its source branch is `uat`.
- Part of restricting `main` so it can only be merged into from `uat`, not directly from feature branches.

## Follow-up (not in this PR)
Once merged, `Require uat source` needs to be added to `main`'s required status checks in branch protection for this to actually take effect.

## Test plan
- [ ] After merge, open a throwaway PR into `main` from a branch other than `uat` and confirm the `Require uat source` check fails.
- [ ] Confirm a PR into `main` from `uat` passes the check.