### PR TITLE
Add PolyForm Noncommercial 1.0.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,137 @@
+PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Copyright (c) TripSit contributors
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright in it
+for any permitted purpose. However, you may only distribute
+the software according to Distribution License and make
+changes or new works based on the software according to
+Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the software. Your license to
+distribute covers distributing the software with changes and
+new works permitted by Changes and New Works License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright TripSit contributors (https://github.com/TripSit/TripBot)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software
+that covers patent claims the licensor can license, or
+becomes able to license, that you would infringe by using
+the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the
+benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization, or
+government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent
+license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the
+software not covered by your licenses, your licenses can
+nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past
+violations, within 32 days of receiving notice. Otherwise,
+all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be
+liable to you for any damages arising out of these terms or
+the use or nature of the software, under any kind of legal
+claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship, or
+other kind of organization that you work for, plus all
+organizations that have control over, are under the control
+of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise. Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+**Trademark** means trademarks, service marks, and similar
+rights.

--- a/README.MD
+++ b/README.MD
@@ -5,6 +5,7 @@
 + [How to use](#invite)
 + [Contribute](#contribute)
 + [Authors](#contributors)
++ [License](#license)
 
 ## About
 TripBot is multi-platform open-source bot that is a major part of the **[TripSit](https://tripsit.me)** project.
@@ -244,5 +245,11 @@ You can access it via http://localhost:5050 (maybe idk)
 This is a simple API that allows you to interact with the database.
 
 V1 : legacy tripbot APi that interacts with static .json files.
+
+## License
+
+TripBot is source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE). You're free to use, copy,
+modify, and distribute the code (including forks) for any noncommercial purpose. Selling the software, or using it
+to provide a commercial product or service, is not permitted.
 
 V2 : the new prisma api that interacts with postgres for the appeal system.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "Change",
     "theimperious1"
   ],
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "bugs": {
     "url": "https://github.com/TripSit/TripBot/issues"
   },


### PR DESCRIPTION
## Summary
- Adds a `LICENSE` file using the PolyForm Noncommercial 1.0.0 license, copyright TripSit contributors.
- Updates the `license` field in `package.json` from `MIT` to the SPDX identifier `PolyForm-Noncommercial-1.0.0`.
- Adds a License section to the README explaining the terms in plain language.

## Why
TripSit wants TripBot to stay open for people to use, study, fork, and modify, but doesn't want anyone selling it or offering it commercially. MIT allowed unrestricted commercial use, so it no longer matched intent. PolyForm Noncommercial is a purpose-built, well-drafted license for this exact case (full rights short of commercial use), as opposed to layering a "Commons Clause" rider onto a separate permissive license, or using a Creative Commons license (not recommended for software).

## Note for reviewers
This is a licensing/legal change, not a code change — worth a sanity check from someone with legal background before treating it as final, since it changes the terms under which the whole project is distributed.

## Test plan
- [ ] N/A (documentation/license only, no code behavior changes)