### PR TITLE
Document rule: sync feature branches from uat before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,6 +346,9 @@ failure as a source-code failure.
 - Do not include generated `build/`, coverage, `.env`, generated Prisma clients, logs, caches, or local database data.
 - For PR conflict work, inspect the actual canonical PR and its real base before resolving conflicts; do not assume a fork's
   `origin` is the authoritative upstream.
+- Before opening a pull request from a feature branch, pull the latest `uat` (the usual PR base) into it first so the
+  branch is up to date and the push won't be rejected as non-fast-forward. Prefer branching fresh from `uat` over
+  rebasing an existing shared/pushed branch, since rewriting history on a branch others may have pulled is riskier.
 
 ## Definition of done
 


### PR DESCRIPTION
## Summary
- Adds a rule to `AGENTS.md`'s "Git and change hygiene" section: pull the latest `uat` into a feature branch before opening a PR against it, to avoid non-fast-forward push rejections.
- States a preference for branching fresh from `uat` over rebasing an already-pushed/shared branch, since rewriting shared history is riskier.

## Why
Hit a rejected push while working on a feature branch that had drifted behind `uat` (another commit landed on the remote branch in the meantime). Rebasing a shared branch was the wrong move, so we branched fresh from `uat` instead and want that convention documented for future work (human and AI-agent) in this repo.

## Test plan
- [x] Docs-only change; reviewed rendered Markdown and diff for correctness
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)