### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages or logs if available. -->
+
+## Environment
+
+- TripBot context (Discord command, API route, etc.):
+- Environment (production, staging/uat, local):
+
+## Additional context
+
+<!-- Anything else relevant: screenshots, related issues/PRs, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask in Discord
+    url: https://discord.gg/tripsit
+    about: For questions or discussion, please ask in our Discord guild instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem does this solve, or what need does it address? -->
+
+## Proposed solution
+
+<!-- What you'd like to see happen. -->
+
+## Alternatives considered
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Anything else relevant: mockups, related issues/PRs, links to Discord discussion, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues with "Closes #123" if applicable. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+- [ ] Other (describe above)
+
+## Checklist
+
+- [ ] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
+- [ ] Lint passes for changed files (`npx eslint --ext .ts,.js path/to/file.ts`)
+- [ ] Type-check passes (`npx tsc --noEmit --pretty false`)
+- [ ] Relevant tests pass (`npm run tripbot:test -- --runInBand`)
+- [ ] No secrets, `.env` values, database dumps, or user data included
+- [ ] Discord command definitions changed? Note that deployment must be requested separately (not done in this PR)
+
+## Test plan
+
+<!-- How did you verify this change? What did you run, and what were the results? -->


### PR DESCRIPTION
## Summary

Adds a pull request template and issue templates so contributions have a consistent structure to follow, addressing the gap noted in review: there was no `.github/PULL_REQUEST_TEMPLATE.md` or `.github/ISSUE_TEMPLATE/` checklist.

- `.github/PULL_REQUEST_TEMPLATE.md` — summary, type of change, and a checklist mirroring the checks already documented in [CONTRIBUTING.md](../blob/uat/CONTRIBUTING.md) (branch based on `uat`, lint/type-check/test commands, no secrets/user data, Discord command deployment note), plus a test plan section.
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report template (repro steps, expected/actual behavior, environment).
- `.github/ISSUE_TEMPLATE/feature_request.md` — structured feature request template (problem, proposed solution, alternatives).
- `.github/ISSUE_TEMPLATE/config.yml` — keeps blank issues enabled and adds a contact link to the TripSit Discord for questions/discussion, per the existing guidance in CONTRIBUTING.md.

## Type of change

- [x] Documentation

## Checklist

- [x] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
- [x] No secrets, `.env` values, database dumps, or user data included
- [ ] N/A: no code changes, so lint/type-check/tests are not applicable

## Test plan

Documentation-only change. Verified Markdown/YAML render correctly and content matches conventions already documented in CONTRIBUTING.md and AGENTS.md.