### PR TITLE
Add missing .editorconfig; drop stale lint-staged reference

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,7 +40,7 @@
   },
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "package.json": ".drone.yml, .eslintignore, .eslintrc, .gitattributes, sonar-project.properties, docker-compose.yml, docker-compose.override.yml, .dockerignore, package-lock.json, .eslintcache, .npmrc, .nvmrc, tsconfig.json, tsconfig.tsbuildinfo, .tsbuildinfo, .editorconfig, .lintstagedrc.mjs, prisma.config.ts, .env, .env.example, .gitignore, eslint.config.mjs"
+    "package.json": ".drone.yml, .eslintignore, .eslintrc, .gitattributes, sonar-project.properties, docker-compose.yml, docker-compose.override.yml, .dockerignore, package-lock.json, .eslintcache, .npmrc, .nvmrc, tsconfig.json, tsconfig.tsbuildinfo, .tsbuildinfo, .editorconfig, prisma.config.ts, .env, .env.example, .gitignore, eslint.config.mjs"
   },
   "search.exclude": {
     "**/.next": true,


### PR DESCRIPTION
## Summary
- Adds a real `.editorconfig` (2-space indent, LF, UTF-8, 120-col lines, final newline) matching the style already documented for this repo and enforced by ESLint/`.gitattributes`.
- Removes the stale `.lintstagedrc.mjs` entry from `.vscode/settings.json`'s file-nesting pattern — that file never existed; lint-staged is configured inline in `package.json`.

`.vscode/settings.json` referenced both `.editorconfig` and `.lintstagedrc.mjs` as if they existed, leaving non-VS Code editors without a baseline indentation/charset config.

## Test plan
- [x] Reviewed diff for scope (2 files, no unrelated changes)
- [ ] Confirm VS Code's explorer file-nesting still groups `package.json`'s siblings correctly with `.editorconfig` present