### PR TITLE
Allowlist a few more read-only commands to reduce permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,11 @@
       "Bash(npx jest*)",
       "Bash(npx prisma validate*)",
       "Bash(npx prisma format*)",
-      "Bash(npx prisma generate*)"
+      "Bash(npx prisma generate*)",
+      "Bash(git fetch *)",
+      "Bash(npm view *)",
+      "Bash(docker compose config *)",
+      "Bash(npm audit)"
     ],
     "ask": [
       "Bash(npx prisma migrate*)",


### PR DESCRIPTION
## Summary
- Adds `git fetch *`, `npm view *`, `docker compose config *`, and `npm audit` (exact) to `permissions.allow` in `.claude/settings.json`
- Selected from actual usage frequency across recent Claude Code session transcripts, filtered to commands that are read-only, not already covered by Claude Code's built-in auto-allow list, and not already present in this repo's allowlist

## Test plan
- [x] `git diff --check`
- [x] Verified JSON validity of `.claude/settings.json`
- [ ] N/A — config-only change, no code/build/test impact