### PR TITLE
Fix devcontainer bind mount and hot-reload; add postCreateCommand

### DIFF
--- a/.devcontainer/FIRSTRUN.MD
+++ b/.devcontainer/FIRSTRUN.MD
@@ -4,10 +4,13 @@ Congrats on making it this far!
 You have just a little more setup to complete:
 
 0) Wait for setup in the terminal to finish. You'll know it's done when you see the "Welcome to codespace!" message.
-1) Open NPM Scripts via the hamburger dots in the top left
-2) Run the cs-deploy script, this registers the bot commands with your bot application
-2.1) If you get an error about missing token or something, make sure you update your github codespace secrts to match the .env.example file
-2.2) At least your discord client ID and token, everything else is optional.
-2.3) If you're not going to use TripSit's dev guild, then change the guild ID.
-3) Run the cs-start script, this compiles the bot into the /build folder and runs it via nodemon.
-4) That's it! Start developing and have fun. The changes you make to the SRC folder will be reflected in the container.
+1) The bot starts automatically once the container is up (via the `postStartCommand` in `devcontainer.json`), compiling
+   with `tsc-watch` and running in a `tmux` session. Open NPM Scripts via the hamburger dots in the top left and run
+   `tripbot:logs` to attach to it and see the output.
+1.1) If you see errors about a missing token or similar, update your GitHub Codespace secrets to match `.env.example`.
+1.2) At minimum you need your Discord client ID and token; everything else is optional.
+1.3) If you're not going to use TripSit's dev guild, change the guild ID.
+2) Run the `tripbot:deployCommands` script to register the bot's slash commands with your bot application. You'll need
+   to re-run this any time you add a command or change an existing command's options.
+3) That's it! Start developing and have fun. The changes you make to the `src` folder will be reflected in the
+   container and trigger an automatic rebuild/restart.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"service": "tripbot",
 	"workspaceFolder": "/workspaces/tripbot",
 	"shutdownAction": "stopCompose",
+	"postCreateCommand": "npm ci",
   	"postStartCommand": "npm run tripbot:dev",
 	"customizations": {
 	  "vscode": {

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,21 +12,17 @@ node_modules
 # Files
 # .dockerignore
 # .drone.yml
-# .env - We should def move to docker secrets 
+# .env - We should def move to docker secrets
 # .env.example
 # .eslintignore
 # .eslintrc
 # .gitattributes
 # .gitignore
-.gitpod.yml
-captain-definition
 # docker-compose.yml - Not needed, but is good for reference if anyone wants to inspect the container
 # Dockerfile - Same
 FIRSTRUN.MD
-# nodemon.json - We need this to run the container in development mode
 # package-lock.json - We need this to install the dependencies!
 # package.json - Same!
 # README.MD
 # sonar-project.properties
-tempStorage.json
 # tsconfig.json - We need this to compile the code!

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ Jest Testing
 SonarQube Code Quality
 Docker Containerized
 ESlint Linting
-Nodemon Hot Reloading
+tsc-watch Hot Reloading
 TSC Auto Building
 Drone Continuous Integration
 
@@ -45,13 +45,12 @@ Drone Continuous Integration
 
 **Requirements**
 1) Docker. You can get it [here](https://www.docker.com/products/docker-desktop).
-2) A discord bot application. You can get one [here](https://discord.com/developers/applications).
-
+2) VSCode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), or [GitHub Codespaces](https://github.com/features/codespaces). Development happens inside the devcontainer defined in `.devcontainer/`.
+3) A discord bot application. You can get one [here](https://discord.com/developers/applications).
 
 **Optional**
-1) VSCode. You can get it [here](https://code.visualstudio.com/).
-2) ESLint extension for VSCode. You can get it [here](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
-3) Invite the discord bot to the tripsit dev guild. Ask Moonbear for an invite link. The bot will not work properly without doing this.
+1) ESLint extension for VSCode. You can get it [here](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). It's already included in the devcontainer's recommended extensions.
+2) Invite the discord bot to the tripsit dev guild. Ask Moonbear for an invite link. The bot will not work properly without doing this.
 
 **Setup the bot**
 
@@ -59,38 +58,34 @@ Clone the repository
 
 ``` git clone https://github.com/TripSit/TripBot.git```
 
-Copy env.example to .env and fill in these fields. You only /need/ the discord stuff like the token and client ID
+Copy `.env.example` to `.env` and fill in these fields. You only /need/ the discord stuff like the token and client ID.
 
-Install the dependencies locally so that VSCode can use them for linting and intellisense.
-
-```npm install```
+Open the folder in VSCode and choose **Reopen in Container** (or open it as a GitHub Codespace). This builds the dev
+image, starts the database, and mounts the whole repo into the container so edits and commits made either on your
+host machine or inside the container show up in both places.
 
 **Start the bot**
 
-This will start up the tripbot_database, build the bot, and run the bot in a container.
-The database container just basically sits there being a stable database, you don't need to check it's logs or anything.
-
-```npm run tripbot:start```
-
-You will likely want to immediately check the logs of the container to make sure it started up correctly.
+Nothing to do here — the devcontainer's `postStartCommand` runs `npm run tripbot:dev` automatically once the
+container is up, compiling with `tsc-watch` and running the bot in a `tmux` session.
 
 **View logs**
 
 ```npm run tripbot:logs```
 
-This will show you the logs of tripbot from inside the container.
+This attaches to the `tmux` session and shows you the bot's live output. Detach without stopping it with `Ctrl+B` then `D`.
 
 **Deploy commands**
 
-This command will happen automatically when you build the TripBot container and tells discord what commands are available.
+Registering slash commands with Discord is *not* automatic — run this once after first setup, and again any time you
+add a command or change an existing command's options:
 
 ```npm run tripbot:deployCommands```
 
-**If you create a new command, or modify the options in an existing command, you'll need to deploy commands again.**
-
 **Develop**
 
-The container will watch the /src folder for changes and rebuild the bot when you save a file.
+The devcontainer watches the whole repo for changes (via polling, since native file-change events don't reliably
+cross the Windows/Mac-to-Linux bind mount) and rebuilds/restarts the bot when you save a file under `src/`.
 
 **Lint**
 
@@ -218,7 +213,7 @@ Restart the bot and you should be good to go.
 
 #### Postgres ###
 
-```npm run postgres```
+```npm run db:start```
 
 We use postgres for our database.
 
@@ -242,9 +237,7 @@ You can access it via http://localhost:5050 (maybe idk)
 
 #### API ###
 
-```npm run api```
-
-This is a simple API that allows you to interact with the database.
+The API runs as part of the same bot process (see `src/api/app.ts`) — there's no separate script to start it.
 
 V1 : legacy tripbot APi that interacts with static .json files.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       - tripbot_website-net
       - moodle_data-net
     volumes:
-      - ./src:/workspaces/tripbot/src # Needed for hot-reloading of source code
+      - .:/workspaces/tripbot # Mount the whole repo so edits/commits made in the container reach the host
+      - /workspaces/tripbot/node_modules # Anonymous volume: keep the image's Linux-built native deps (argon2, canvas) out from under the host bind mount
     labels:
       - com.centurylinklabs.watchtower.enable=false
       - traefik.enable=true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -134,18 +134,13 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  // // NEW: Options for file/directory watching
-  // "watchOptions": {
-  //   // Use native file system events for files and directories
-  //   "watchFile": "useFsEvents",
-  //   "watchDirectory": "useFsEvents",
-  //   // Poll files for updates more frequently
-  //   // when they're updated a lot.
-  //   "fallbackPolling": "dynamicPriority",
-  //   // Don't coalesce watch notification
-  //   "synchronousWatchDirectory": true,
-  //   // Finally, two additional settings for reducing the amount of possible
-  //   // files to track  work from these directories
-  //   "excludeDirectories": ["**/node_modules", "_build", "build"],
-  // }
+  // Native fs events (inotify) generally don't propagate through a Docker Desktop bind mount from a
+  // Windows/Mac host into the Linux container, so tsc-watch never sees saved changes without polling.
+  "watchOptions": {
+    "watchFile": "priorityPollingInterval",
+    "watchDirectory": "dynamicPriorityPolling",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": true,
+    "excludeDirectories": ["**/node_modules", "build"]
+  }
 }


### PR DESCRIPTION
## Summary
- Only `./src` was bind-mounted into the devcontainer, so edits/commits made anywhere else (including `.git`) lived only in the container's writable layer and were lost on rebuild. Now the whole repo is mounted, with an anonymous volume over `node_modules` so the container keeps its Linux-built native deps (argon2, canvas) instead of picking up a host-installed copy.
- `tsc-watch`'s native fs-event watching doesn't reliably cross a Docker Desktop bind mount from Windows/Mac into the Linux container, so saved changes weren't triggering a rebuild/restart. Enabled the (previously commented-out) polling `watchOptions` in `tsconfig.json`.
- Added `postCreateCommand: npm ci` to `devcontainer.json` so dependencies are refreshed against the current lockfile when the container is created.
- Corrected onboarding docs that had drifted from reality: `FIRSTRUN.MD` referenced `cs-deploy`/`cs-start` scripts that don't exist; `README.MD`'s "How to build" described a pre-devcontainer workflow and referenced dead `npm run postgres`/`npm run api` scripts and a "Nodemon" feature that isn't used; `.dockerignore` had stale comments for files no longer in the repo.

## Test plan
- [x] `npx tsc --noEmit --pretty false` passes clean
- [x] `docker compose config -q` validates the compose file
- [ ] Rebuild the devcontainer and confirm: edits/commits outside `src/` now show up on the host, and saving a file under `src/` triggers a `tsc-watch` rebuild/restart