### PR TITLE
Promote uat to main (#1176)

### DIFF
--- a/.github/workflows/PullRequestOpenAll.yml
+++ b/.github/workflows/PullRequestOpenAll.yml
@@ -79,38 +79,24 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: --max-old-space-size=7168
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-      - name: Generate Prisma clients
-        run: npm run db:generate
-      - name: Type check
-        run: npx tsc --noEmit
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: --max-old-space-size=7168
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+          languages: javascript
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-      - name: Generate Prisma clients
-        run: npm run db:generate
-      - name: Copy env
-        run: cp .env.example .env
-      - name: Test
-        run: npx jest --silent -c ./src/jest/jest.config.ts
+          category: "/language:javascript"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,6 +346,9 @@ failure as a source-code failure.
 - Do not include generated `build/`, coverage, `.env`, generated Prisma clients, logs, caches, or local database data.
 - For PR conflict work, inspect the actual canonical PR and its real base before resolving conflicts; do not assume a fork's
   `origin` is the authoritative upstream.
+- Before opening a pull request from a feature branch, pull the latest `uat` (the usual PR base) into it first so the
+  branch is up to date and the push won't be rejected as non-fast-forward. Prefer branching fresh from `uat` over
+  rebasing an existing shared/pushed branch, since rewriting history on a branch others may have pulled is riskier.
 
 ## Definition of done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to TripBot
+
+Thanks for your interest in contributing! This file is the entry point for contribution mechanics. For full
+repository conventions (architecture rules, style, safety constraints) see [AGENTS.md](AGENTS.md); for project setup
+and local development see [README.MD](README.MD).
+
+## Getting started
+
+1. [Join our Discord guild](https://discord.gg/tripsit) — development discussion happens there.
+2. Follow the **How to build** section in [README.MD](README.MD) to get a local instance running.
+3. Read [AGENTS.md](AGENTS.md) before making changes — it covers toolchain requirements, architecture rules, style
+   conventions, and safety constraints for this repository.
+
+## Branching and pull requests
+
+- `main` is the production branch. `uat` is the staging/integration branch.
+- Feature branches are created from `uat` and opened as pull requests **into `uat`**, not `main`. A GitHub Action
+  (`GuardMainSource`) enforces that only `uat` may open a pull request into `main`.
+- Before opening a pull request, pull the latest `uat` into your feature branch first so it's up to date and the
+  push won't be rejected as non-fast-forward. Prefer branching fresh from `uat` over rebasing an existing
+  shared/pushed branch, since rewriting history on a branch others may have pulled is riskier.
+- Keep commits focused and use the repository's concise, imperative commit message style (see `git log` for
+  examples).
+- Do not force-push shared branches, rewrite committed migrations, or use destructive Git commands to "clean up" a
+  branch.
+
+## Running checks before opening a PR
+
+Every pull request into `main` or `uat` runs lint, type-check/build, tests, and CodeQL. Run the equivalent checks
+locally first:
+
+```powershell
+# Install dependencies (matches CI)
+npm ci
+
+# Lint (repo-wide lint may surface unrelated pre-existing failures; prefer linting just your changed files)
+npx eslint --ext .ts,.js path/to/file.ts
+
+# Generate Prisma clients, then type-check
+npx prisma generate --schema ./src/prisma/tripbot/schema.prisma
+npx prisma generate --schema ./src/prisma/moodle/schema.prisma
+npx tsc --noEmit --pretty false
+
+# Run the active Jest suite
+npm run tripbot:test -- --runInBand
+```
+
+See [AGENTS.md](AGENTS.md#verification-matrix) for the full verification matrix mapping change type to the minimum
+checks expected (documentation, TypeScript logic, Discord commands, API routes, Prisma schema/migrations, etc.).
+
+## Scope and safety
+
+- Keep pull requests scoped to the problem they solve — avoid unrelated refactors, formatting, or drive-by renames.
+- Treat changes to drug information, dosage text, crisis resources, moderation, privacy, and user records as
+  high-impact: preserve established wording and data sources, and don't weaken existing safety checks.
+- Never commit `.env`, tokens, passwords, private URLs, production identifiers, database dumps, or user data.
+
+## License
+
+TripBot is source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE). By contributing, you agree
+your contributions are provided under the same license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,137 @@
+PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Copyright (c) TripSit contributors
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright in it
+for any permitted purpose. However, you may only distribute
+the software according to Distribution License and make
+changes or new works based on the software according to
+Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the software. Your license to
+distribute covers distributing the software with changes and
+new works permitted by Changes and New Works License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright TripSit contributors (https://github.com/TripSit/TripBot)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software
+that covers patent claims the licensor can license, or
+becomes able to license, that you would infringe by using
+the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the
+benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization, or
+government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent
+license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the
+software not covered by your licenses, your licenses can
+nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past
+violations, within 32 days of receiving notice. Otherwise,
+all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be
+liable to you for any damages arising out of these terms or
+the use or nature of the software, under any kind of legal
+claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship, or
+other kind of organization that you work for, plus all
+organizations that have control over, are under the control
+of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise. Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+**Trademark** means trademarks, service marks, and similar
+rights.

--- a/README.MD
+++ b/README.MD
@@ -5,6 +5,9 @@
 + [How to use](#invite)
 + [Contribute](#contribute)
 + [Authors](#contributors)
++ [License](#license)
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch/PR conventions and how to run checks before opening a pull request.
 
 ## About
 TripBot is multi-platform open-source bot that is a major part of the **[TripSit](https://tripsit.me)** project.
@@ -244,5 +247,11 @@ You can access it via http://localhost:5050 (maybe idk)
 This is a simple API that allows you to interact with the database.
 
 V1 : legacy tripbot APi that interacts with static .json files.
+
+## License
+
+TripBot is source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE). You're free to use, copy,
+modify, and distribute the code (including forks) for any noncommercial purpose. Selling the software, or using it
+to provide a commercial product or service, is not permitted.
 
 V2 : the new prisma api that interacts with postgres for the appeal system.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "Change",
     "theimperious1"
   ],
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "bugs": {
     "url": "https://github.com/TripSit/TripBot/issues"
   },


### PR DESCRIPTION
* Add UAT pipeline: CI checks + Drone deploy for uat branch (#1163)

* Add UAT pipeline: uat branch CI checks and Drone deploy

Feature branches now PR into uat with lint/build/test/CodeQL checks, auto-merge on green, and a Drone pipeline that deploys to the dedicated UAT server. uat -> main promotion stays a manually opened, human-approved PR.

- PullRequestOpenAll.yml: retarget dead `development` trigger to `uat`, add a Build (tsc --noEmit) job, re-enable the Test job (was commented out, and referenced a jest config that no longer exists)
- New PushToUat.yml mirrors PushToMain.yml for the uat branch
- .drone.yml: fix a duplicate top-level `trigger:` key that was silently dropping the branch restriction on the prod pipeline, add a second pipeline deploying to UAT via UAT_-prefixed secrets
- jest.config.ts: mock @keycloak/keycloak-admin-client, which is ESM-only and was crashing every test suite that imports the API app before any assertions could run

* Fix implicit-any params flagged by the new Build check

Pre-existing type errors in functions.ts that a fresh npm ci + tsc --noEmit surfaces (my local node_modules had drifted from package-lock.json and masked these). Annotated with the actual SDK types instead of relying on inference.

* Generate Prisma clients before running tests in CI

The Test job installed deps but never ran db:generate, so @db/tripbot failed to resolve and cascaded into a false implicit-any error in modUtils.ts (its types derive from a Prisma call that collapsed to any once the import broke). Test job now mirrors Build's setup.

* Fix failing tests: real alias-resolution bug + stale doc assertions

- g.combo.ts: cleanDrugName() only matched exact drug-database keys, never aliases, so combo('dxm', 'mdma') reported dxm as unknown even though it's a documented alias for dextromethorphan. Added the same exact-then-alias resolution g.drug.ts already does. Shared by both the Discord /combo command and the getInteraction API route.
- api.test.ts / v1.test.ts: the endpoint self-documentation responses were intentionally upgraded from flat endpoint-name arrays to structured input/output/example docs (app.ts, v1/index.ts), and the /v1 + /v2 entries were deliberately commented out of app.ts's top-level endpoint list. Tests still asserted the old shape; updated to match current, intentional behavior.

* Scope UAT Drone pipeline to a dedicated env:uat runner (#1164)

Live's single Drone server/runner turned out not to fit the actual requirement: separate access control (junior devs on drone.tripsit.io without touching drone.tripsit.me) needs a genuinely separate Drone server, not just a second runner on the same one. Since both servers will evaluate this same .drone.yml if the repo is activated on both, this node selector is the safety net -- Live's unlabeled runner can never be scheduled for the UAT pipeline, regardless of which Drone server dispatches it.

Deliberately not touching the prod pipeline yet: adding node: {env: prod} now would immediately break live deploys, since Live's runner doesn't have that label yet. That happens once the label's confirmed live on that box.

* Update drone.yml

* Testing pipeline

* Prune unused deps and deduplicate CI workflows (#1169)

* Prune unused/duplicate npm dependencies

Removes telegraf and youtube-search-without-api-key, which are only referenced from code under src/telegram/ and commands/archive/ that is excluded from the TS build, ESLint, and Jest config — the packages were dead weight in the dependency tree even though the source files that reference them are kept as-is. Also replaces the single moment usage in modUtils.ts with the already-present luxon Duration API so moment can be dropped, and removes husky's duplicate listing under dependencies (it belongs in devDependencies only).



* Remove unused lint and build jobs from workflow files

---------



* Add GuardMainSource workflow to restrict PRs into main to uat (#1170)

Fails the required check for any pull request into main whose source branch isn't uat, so main can only be merged into from uat.

* Add PolyForm Noncommercial 1.0.0 license (#1172)

TripSit wants the code open for use, forking, and modification, but not for resale or commercial exploitation. Adds LICENSE, updates the package.json license field, and documents it in the README.



* Fix duplicate test job and non-functional CodeQL job in PullRequestOpenAll (#1173)

* Add PolyForm Noncommercial 1.0.0 license

TripSit wants the code open for use, forking, and modification, but not for resale or commercial exploitation. Adds LICENSE, updates the package.json license field, and documents it in the README.



* Fix duplicate test job and non-functional CodeQL job in PullRequestOpenAll

The test job was defined twice (identical), silently discarding the first. The codeql job never ran CodeQL analysis - it was a copy of build's type-check step, so the CodeQL check passed without any actual scanning. Wired the codeql job to github/codeql-action, matching PushToUat.yml.



---------



* Document rule: sync feature branches from uat before opening a PR (#1174)

We hit a rejected non-fast-forward push because a feature branch was stale relative to uat. Codify branching fresh from uat (over rebasing a shared branch) as the preferred fix.



* Document PR conventions; add CONTRIBUTING.md (#1175)

* Document rule: sync feature branches from uat before opening a PR

We hit a rejected non-fast-forward push because a feature branch was stale relative to uat. Codify branching fresh from uat (over rebasing a shared branch) as the preferred fix.



* Add CONTRIBUTING.md with branch/PR conventions and check commands

Consolidates branch/PR rules and local verification commands from AGENTS.md into a dedicated entry point for new contributors, linked from README.MD.



---------



---------